### PR TITLE
Restructure Supex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ supex-*.tar
 
 # The organization dir.
 /orga/
+
+# xref files
+xref*
+

--- a/lib/supex.ex
+++ b/lib/supex.ex
@@ -263,7 +263,6 @@ defmodule Supex do
     sc_command |> Pan.center() |> Command.play(name) |> Sclang.execute()
   end
 
-
   @doc since: "0.2.0"
   @spec stop() :: %Sclang{}
   def stop(), do: Sclang.stop_playing()

--- a/lib/supex.ex
+++ b/lib/supex.ex
@@ -46,8 +46,10 @@ defmodule Supex do
 
   ```elixir
   iex> import Supex
-  iex> osc |> freq(269) |> name("y") |> play
-  iex> osc |> name("y") |> stop
+  iex> osc |> freq(269) |> play("y")
+  iex> stop("y")
+  # or stop all
+  iex> stop
   ```
 
   ▶ Modulate volume of a sine wave using another sine as LFO:
@@ -56,14 +58,18 @@ defmodule Supex do
   iex> import Supex
   iex> osc |> mul(osc |> freq(2) |> mul(0.4) |> add(0.5) |> lfo) |> play
   iex> osc |> stop
+  # or stop all
+  iex> stop
   ```
 
   ▶ Modulate a pulse wave's frequency and width:
 
   ```elixir
   iex> import Supex
-  iex> osc(:pulse) |> freq("SinOsc.kr(0.4).range(169, 269)") |> width("SinOsc.kr(6.9).range(0.01, 0.8)")|> mul(0.3) |> name("x") |> play
-  iex> osc |> name("x") |> stop
+  iex> osc(:pulse) |> freq("SinOsc.kr(0.4).range(169, 269)") |> width("SinOsc.kr(6.9).range(0.01, 0.8)")|> mul(0.3) |> play
+  iex> stop("x")
+  # or stop all
+  iex> stop
   ```
 
   🔤 Send a raw SuperCollider expression:
@@ -71,7 +77,9 @@ defmodule Supex do
   ```elixir
   iex> import Supex
   iex> "RLPF.ar(Pulse.ar([100, 250], 0.5, 0.1), XLine.kr(8000, 400, 5), 0.05)" |> play
-  iex> osc |> name("z") |> stop
+  iex> stop("x")
+  # or stop all
+  iex> stop
   ```
 
   ## ⚠️ Disclaimer
@@ -79,14 +87,27 @@ defmodule Supex do
   SuperCollider and Supex can produce loud, sudden sounds.
   Use volume control and a limiter to protect your ears.
   Avoid hearing damage.
+
+  ## 🛠️ Note
+
+  Supex is in early development.
+  Expect API changes.
   """
 
+  alias Supex.Command
   alias Supex.Pan
   alias Supex.Synth
   alias Supex.Sclang
   alias Supex.Ugen
 
-  @spec osc() :: struct()
+  defstruct ugen: nil
+
+  # def to_sc_command(%Supex{} = supex) do
+  #  %Supex{ugen: ugen} = supex
+
+  #  ugen |> Ugen.to_sc_command()
+  # end
+
   @doc """
   Create a oscillator.
   `type` can be:
@@ -97,8 +118,35 @@ defmodule Supex do
 
   Defaults to `:sin`.
   """
+  @deprecated "Use Supex.sin/0 instead"
   @doc since: "0.1.0"
-  defdelegate osc(type \\ :sin), to: Ugen
+  @spec osc() :: struct()
+  def osc(), do: Ugen.sin()
+
+  @deprecated "Use Supex.sin/0, Supex.saw/0, or Supex.pulse/0 instead"
+  @doc since: "0.1.0"
+  @spec osc(atom()) :: struct()
+  def osc(:sin), do: Ugen.sin()
+  def osc(:saw), do: Ugen.saw()
+  def osc(:pulse), do: Ugen.pulse()
+
+  @doc """
+  Create a sine oscillator.
+  """
+  @doc since: "0.2.0"
+  def sin(), do: Ugen.sin()
+
+  @doc """
+  Create a saw oscillator.
+  """
+  @doc since: "0.2.0"
+  def saw(), do: Ugen.saw()
+
+  @doc """
+  Create a pulse oscillator.
+  """
+  @doc since: "0.2.0"
+  def pulse(), do: Ugen.pulse()
 
   @doc """
   Transforms a "normal" oscillator to a LFO to use it as a modulator.
@@ -119,55 +167,51 @@ defmodule Supex do
     iex> osc(:pulse) |> mul(osc|>freq(2)|>mul(0.4)|>add(0.5)|>lfo) |> freq(osc(:saw)|>freq(0.2)|>mul(100)|>add(100)|>lfo) |> play
   """
   @doc since: "0.1.0"
-  @spec lfo(%Ugen{}) :: binary()
+  @spec lfo(struct()) :: struct()
   defdelegate lfo(ugen), to: Ugen
 
   @doc """
   Tune the frequency of an oscillator.
+
   `freq` can be an integer or float.
   """
   @doc since: "0.1.0"
-  @spec freq(%Ugen{}, integer() | float() | binary()) :: struct()
+  @spec freq(struct(), integer() | float() | binary() | struct()) :: struct()
   defdelegate freq(ugen, freq), to: Ugen
 
   @doc """
   The pulse width of an pulse wave oscillator.
+
   `width` should be a value between `0.01` and `0.99`.
   """
   @doc since: "0.1.0"
-  @spec width(%Ugen{}, integer() | float() | binary()) :: struct()
+  @spec width(struct(), integer() | float() | binary() | struct()) :: struct()
   defdelegate width(ugen, width), to: Ugen
 
   @doc """
   The phase of a sinus wave.
   """
   @doc since: "0.1.0"
-  @spec phase(%Ugen{}, integer() | float() | binary()) :: struct()
+  @spec phase(struct(), integer() | float() | binary() | struct()) :: struct()
   defdelegate phase(ugen, phase), to: Ugen
 
   @doc """
   Multiplication of the signal.
+
   Chose values between `0.1` and `1` for not hurting your ears.
   """
   @doc since: "0.1.0"
-  @spec mul(%Ugen{}, integer() | float() | binary()) :: struct()
+  @spec mul(struct(), integer() | float() | binary() | struct()) :: struct()
   defdelegate mul(ugen, mul), to: Ugen
 
   @doc """
   Add the value to the signal.
+
   Values can be `0.1` or `1` for example.
   """
   @doc since: "0.1.0"
-  @spec add(%Ugen{}, integer() | float() | binary()) :: struct()
+  @spec add(struct(), integer() | float() | binary() | struct()) :: struct()
   defdelegate add(ugen, add), to: Ugen
-
-  @doc """
-  Adds a name for referencing.
-  e.g. with a name the singnal can be stopped on the SuperCollider server.
-  """
-  @doc since: "0.1.0"
-  @spec name(%Ugen{}, binary()) :: struct()
-  defdelegate name(ugen, name), to: Ugen
 
   @doc """
   A synth definition.
@@ -182,33 +226,37 @@ defmodule Supex do
   ## example
 
     iex> import SC
-    iex> osc |> freq(269) |> name("y") |> play
+    iex> osc |> freq(269) |> play
   """
   @doc since: "0.1.0"
-  @spec play(%Ugen{sc_command: binary(), sc_name: binary()} | binary()) :: :ok
-  def play(%Ugen{} = ugen), do: ugen |> Pan.center() |> Ugen.play() |> Sclang.execute()
+  @spec play(struct() | binary()) :: %Sclang{}
+  def play(ugen) when is_struct(ugen), do: ugen |> Command.build() |> play()
 
   @doc since: "0.1.0"
-  def play(sc_command) when is_binary(sc_command),
-    do: sc_command |> Pan.center() |> Ugen.play() |> Sclang.execute()
+  def play(sc_command) when is_binary(sc_command) do
+    sc_command |> Pan.center() |> Command.play() |> Sclang.execute()
+  end
+
+  @doc since: "0.2.0"
+  @spec stop() :: %Sclang{}
+  def stop(), do: Sclang.stop_playing()
 
   @doc """
-  Stop playing a oscillator with a name.
+  Stop playing a sc_command with name reference.
 
   ## example
 
     iex> import SC
-    iex> osc |> name("y") |> stop
+    iex> stop("x")
   """
   @doc since: "0.1.0"
-  @spec stop(%Ugen{sc_name: binary()}) :: :ok
-  def stop(%Ugen{} = ugen) do
-    ugen |> Ugen.stop() |> Sclang.execute()
-  end
+  @spec stop(binary()) :: struct()
+  def stop(name), do: Command.stop(name) |> Sclang.execute()
 
   @doc "Stops all sound playing."
   @doc since: "0.1.0"
-  @spec stop_playing() :: :ok
+  @deprecated "Use Supex.stop/0 instead"
+  @spec stop_playing() :: struct()
   defdelegate stop_playing(), to: Sclang
 
   @doc """
@@ -217,6 +265,6 @@ defmodule Supex do
   Must be a string.
   """
   @doc since: "0.1.0"
-  @spec execute(binary()) :: :ok
+  @spec execute(binary()) :: struct()
   defdelegate execute(sc_command), to: Sclang
 end

--- a/lib/supex.ex
+++ b/lib/supex.ex
@@ -46,7 +46,7 @@ defmodule Supex do
 
   ```elixir
   iex> import Supex
-  iex> osc |> freq(269) |> play("y")
+  iex> sin |> freq(269) |> play("y")
   iex> stop("y")
   # or stop all
   iex> stop
@@ -56,8 +56,8 @@ defmodule Supex do
 
   ```elixir
   iex> import Supex
-  iex> osc |> mul(osc |> freq(2) |> mul(0.4) |> add(0.5) |> lfo) |> play
-  iex> osc |> stop
+  iex> sin |> mul(sin |> freq(2) |> mul(0.4) |> add(0.5) |> lfo) |> play
+  iex> sin |> stop
   # or stop all
   iex> stop
   ```
@@ -66,7 +66,7 @@ defmodule Supex do
 
   ```elixir
   iex> import Supex
-  iex> osc(:pulse) |> freq("SinOsc.kr(0.4).range(169, 269)") |> width("SinOsc.kr(6.9).range(0.01, 0.8)")|> mul(0.3) |> play
+  iex> pulse |> freq("SinOsc.kr(0.4).range(169, 269)") |> width("SinOsc.kr(6.9).range(0.01, 0.8)")|> mul(0.3) |> play
   iex> stop("x")
   # or stop all
   iex> stop
@@ -159,12 +159,12 @@ defmodule Supex do
   Modulate the volume of a sine wave with another sine wave as an LFO:
 
     iex> import SC
-    iex> osc |> mul(osc |> freq(3) |> mul(0.5) |> add(0.5) |> lfo) |> play
-    iex> osc |> stop
+    iex> sin |> mul(osc |> freq(3) |> mul(0.5) |> add(0.5) |> lfo) |> play
+    iex> sin |> stop
 
     or
 
-    iex> osc(:pulse) |> mul(osc|>freq(2)|>mul(0.4)|>add(0.5)|>lfo) |> freq(osc(:saw)|>freq(0.2)|>mul(100)|>add(100)|>lfo) |> play
+    iex> pulse |> mul(sin|>freq(2)|>mul(0.4)|>add(0.5)|>lfo) |> freq(saw|>freq(0.2)|>mul(100)|>add(100)|>lfo) |> play
   """
   @doc since: "0.1.0"
   @spec lfo(struct()) :: struct()
@@ -226,7 +226,7 @@ defmodule Supex do
   ## example
 
     iex> import SC
-    iex> osc |> freq(269) |> play
+    iex> sin |> freq(269) |> play
   """
   @doc since: "0.1.0"
   @spec play(struct() | binary()) :: %Sclang{}
@@ -236,6 +236,33 @@ defmodule Supex do
   def play(sc_command) when is_binary(sc_command) do
     sc_command |> Pan.center() |> Command.play() |> Sclang.execute()
   end
+
+  @doc """
+  Play the composed oscillator, or a raw SuperCollider's command (as a string),
+  and naming it for referencing.
+
+  SuperCollider's command will be refrenced with the given name.
+  You can stop playing it with this name `stop("<name>")`
+
+  SuperCollider only excepts Single-Letter Variables, single chars, like "y", "i";
+  they are global variables that SuperCollider has defined already.
+  So they can be used to refering to the command.
+
+  ## example
+
+    iex> import SC
+    iex> sin |> freq(269) |> play("y")
+    iex> stop("y")
+  """
+  @doc since: "0.2.0"
+  @spec play(struct() | binary(), binary()) :: %Sclang{}
+  def play(ugen, name) when is_struct(ugen), do: ugen |> Command.build() |> play(name)
+
+  @doc since: "0.2.0"
+  def play(sc_command, name) when is_binary(sc_command) do
+    sc_command |> Pan.center() |> Command.play(name) |> Sclang.execute()
+  end
+
 
   @doc since: "0.2.0"
   @spec stop() :: %Sclang{}

--- a/lib/supex/command.ex
+++ b/lib/supex/command.ex
@@ -1,0 +1,48 @@
+defmodule Supex.Command do
+  @moduledoc """
+  Module for SuperCollider commands rendering.
+  """
+
+  @doc """
+  Builds the SuperCollider command from a ugen struct.
+  """
+  def build(ugen), do: ugen |> to_sc_command()
+
+  @doc """
+  Adding play to the sc_command.
+
+  SuperCollider's command will by default refrenced with the variable "x".
+  For example, you can stop playing it with `stop("x")`
+  """
+  def play(sc_command), do: "x = { " <> sc_command <> " }.play"
+
+  @doc """
+  Adding play to the sc_command, and naming it for referencing.
+
+  SuperCollider's command will be refrenced with the given name.
+  You can stop playing it with this name `stop("<name>")`
+
+  SuperCollider only excepts single chars, like "y", "i"...
+  """
+  def play(sc_command, name), do: name <> " = { " <> sc_command <> " }.play"
+
+  @doc """
+  Command for stopping sound playing referenced by name.
+  """
+  def stop(name), do: name <> ".free\n"
+
+  defp to_sc_command(ugen) when is_struct(ugen) do
+    struct_module = ugen.__struct__
+    struct_module.command(ugen |> build_commands_for_lfos())
+  end
+
+  defp build_commands_for_lfos(ugen) do
+    new_key_values =
+      ugen |> Map.from_struct() |> Enum.map(fn {k, v} -> {k, check_for_struct(v)} end)
+
+    ugen |> struct!(new_key_values)
+  end
+
+  defp check_for_struct(value) when is_struct(value), do: value |> to_sc_command()
+  defp check_for_struct(value), do: value
+end

--- a/lib/supex/command.ex
+++ b/lib/supex/command.ex
@@ -26,7 +26,9 @@ defmodule Supex.Command do
   you can also use more than one char for variables.
   These will be declared as SuperCollider's environmental vars.
   """
-  def play(sc_command, name) when byte_size(name) == 1, do: name <> " = { " <> sc_command <> " }.play"
+  def play(sc_command, name) when byte_size(name) == 1,
+    do: name <> " = { " <> sc_command <> " }.play"
+
   def play(sc_command, name), do: "~" <> name <> " = { " <> sc_command <> " }.play"
 
   @doc """

--- a/lib/supex/command.ex
+++ b/lib/supex/command.ex
@@ -22,14 +22,18 @@ defmodule Supex.Command do
   SuperCollider's command will be refrenced with the given name.
   You can stop playing it with this name `stop("<name>")`
 
-  SuperCollider only excepts single chars, like "y", "i"...
+  Although SuperCollider only excepts single chars as global vars, like "y", "i",
+  you can also use more than one char for variables.
+  These will be declared as SuperCollider's environmental vars.
   """
-  def play(sc_command, name), do: name <> " = { " <> sc_command <> " }.play"
+  def play(sc_command, name) when byte_size(name) == 1, do: name <> " = { " <> sc_command <> " }.play"
+  def play(sc_command, name), do: "~" <> name <> " = { " <> sc_command <> " }.play"
 
   @doc """
   Command for stopping sound playing referenced by name.
   """
-  def stop(name), do: name <> ".free\n"
+  def stop(name) when byte_size(name) == 1, do: name <> ".free\n"
+  def stop(name), do: "~" <> name <> ".free\n"
 
   defp to_sc_command(ugen) when is_struct(ugen) do
     struct_module = ugen.__struct__

--- a/lib/supex/example.ex
+++ b/lib/supex/example.ex
@@ -11,25 +11,25 @@ defmodule Supex.Example do
   import Supex
 
   @doc since: "0.1.0"
-  @spec pulse_wave_modulation_with_lfo() :: none()
+  @spec pulse_wave_modulation_with_lfo() :: struct()
   def pulse_wave_modulation_with_lfo() do
-    osc(:pulse)
+    pulse()
     |> mul(
-      osc()
+      sin()
       |> freq(2)
       |> mul(0.4)
       |> add(0.5)
       |> lfo
     )
     |> freq(
-      osc(:saw)
+      saw()
       |> freq(0.1)
       |> mul(100)
       |> add(100)
       |> lfo
     )
     |> width(
-      osc()
+      sin()
       |> freq(6)
       |> mul(0.5)
       |> add(0.5)

--- a/lib/supex/ugen.ex
+++ b/lib/supex/ugen.ex
@@ -5,34 +5,29 @@ defmodule Supex.Ugen do
   ## examples
 
   iex> import Supex.Ugen
-  iex> osc() |> freq(690) |> phase(6) |> mul(0.9) |> add(0.69) |> name("y")
-  %Supex.Ugen{add: 0.69, phase: 6, freq: 690, mul: 0.9, sc_command: "SinOsc.ar(freq: 690, phase: 6, mul: 0.9, add: 0.69);", sc_name: "y"}
-
-  iex> alias Supex.Ugen
-  iex> Ugen.osc(%Supex.Ugen{add: 0.69, phase: 6, freq: 690, mul: 0.9})
-  %Supex.Ugen{add: 0.69, phase: 6, freq: 690, mul: 0.9, sc_command: "SinOsc.ar(freq: 690, phase: 6, mul: 0.9, add: 0.69);"}
+  iex> sin() |> freq(690) |> phase(6) |> mul(0.9) |> add(0.69)
+  %Supex.Ugen.SinOsc{add: 0.69, phase: 6, freq: 690, mul: 0.9}
   """
+  alias Supex.Ugen.Saw
+  alias Supex.Ugen.SinOsc
+  alias Supex.Ugen.Pulse
 
-  defstruct osc: :sin,
-            freq: 440,
-            width: 0.5,
-            phase: 0,
-            mul: 0.1,
-            add: 0,
-            sc_command: "",
-            sc_name: "x",
-            lfo: false
+  defstruct sc_command: "", sc_name: "x"
 
-  @oscillators [:sin, :saw, :pulse]
+  @doc """
+  Create a sine oscillator.
+  """
+  def sin(), do: %SinOsc{}
 
-  @doc since: "0.1.0"
-  @spec osc(:pulse | :saw | :sin | %Supex.Ugen{}) :: struct()
-  def osc(type \\ :sin)
+  @doc """
+  Create a saw oscillator.
+  """
+  def saw(), do: %Saw{}
 
-  def osc(type) when type in @oscillators,
-    do: %__MODULE__{} |> struct!(osc: type) |> update_sc_command()
-
-  def osc(%__MODULE__{} = ugen), do: ugen |> update_sc_command()
+  @doc """
+  Create a pulse oscillator.
+  """
+  def pulse(), do: %Pulse{}
 
   @doc """
   Transforms a "normal" oscillator to a LFO.
@@ -41,86 +36,27 @@ defmodule Supex.Ugen do
   cf. https://doc.sccode.org/Tutorials/Getting-Started/05-Functions-and-Sound.html
   """
   @doc since: "0.1.0"
-  @spec lfo(%Supex.Ugen{}) :: binary()
-  def lfo(%__MODULE__{} = ugen) do
-    %__MODULE__{sc_command: sc_command} = ugen |> struct!(lfo: true) |> update_sc_command()
-    sc_command
-  end
+  @spec lfo(struct()) :: struct()
+  def lfo(ugen), do: ugen |> struct!(lfo: true)
+  # def lfo(%{lfo: _lfo} = ugen), do: ugen |> struct!(lfo: true)
 
   @doc since: "0.1.0"
-  @spec freq(%Supex.Ugen{}, integer() | float() | binary()) :: struct()
-  def freq(%__MODULE__{} = ugen, freq), do: ugen |> struct!(freq: freq) |> update_sc_command()
+  @spec freq(struct(), integer() | float() | binary() | struct()) :: struct()
+  def freq(ugen, freq), do: ugen |> struct!(freq: freq)
 
   @doc since: "0.1.0"
-  @spec width(%Supex.Ugen{}, integer() | float() | binary()) :: struct()
-  def width(%__MODULE__{} = ugen, width), do: ugen |> struct!(width: width) |> update_sc_command()
+  @spec width(struct(), integer() | float() | binary() | struct()) :: struct()
+  def width(ugen, width), do: ugen |> struct!(width: width)
 
   @doc since: "0.1.0"
-  @spec phase(%Supex.Ugen{}, integer() | float() | binary()) :: struct()
-  def phase(%__MODULE__{} = ugen, phase), do: ugen |> struct!(phase: phase) |> update_sc_command()
+  @spec phase(struct(), integer() | float() | binary() | struct()) :: struct()
+  def phase(ugen, phase), do: ugen |> struct!(phase: phase)
 
   @doc since: "0.1.0"
-  @spec mul(%Supex.Ugen{}, integer() | float() | binary()) :: struct()
-  def mul(%__MODULE__{} = ugen, mul), do: ugen |> struct!(mul: mul) |> update_sc_command()
+  @spec mul(struct(), integer() | float() | binary() | struct()) :: struct()
+  def mul(ugen, mul), do: ugen |> struct!(mul: mul)
 
   @doc since: "0.1.0"
-  @spec add(%Supex.Ugen{}, integer() | float() | binary()) :: struct()
-  def add(%__MODULE__{} = ugen, add), do: ugen |> struct!(add: add) |> update_sc_command()
-
-  @doc """
-  Name the oscillator.
-  SuperCollider only excepts single chars, like "y", "i"...
-  """
-  @doc since: "0.1.0"
-  def name(%__MODULE__{} = ugen, sc_name), do: ugen |> struct!(sc_name: sc_name)
-
-  @doc """
-  Adding play to the sc_command, and naming it for referencing.
-
-  You can pass a %Ugen{} struct or a SuperCollider's command.
-
-  Supex and raw SuperCollider's command will by default refrenced with the variable "x".
-  For example, you can stop playing it with `osc() |> name("x") |> stop()`
-  """
-  @doc since: "0.1.0"
-  @spec play(binary() | %Supex.Ugen{}) :: <<_::64, _::_*8>>
-  def play(%__MODULE__{} = ugen) do
-    %__MODULE__{sc_command: sc_command, sc_name: sc_name} = ugen
-    sc_name <> " = { " <> sc_command <> " }.play"
-  end
-
-  def play(sc_command) when is_binary(sc_command), do: "x = { " <> sc_command <> " }.play"
-
-  @doc """
-  Stop sc_command with name reference.
-  """
-  @doc since: "0.1.0"
-  @spec stop(%Supex.Ugen{}) :: <<_::48, _::_*8>>
-  def stop(%__MODULE__{} = ugen) do
-    %__MODULE__{sc_name: sc_name} = ugen
-    sc_name <> ".free\n"
-  end
-
-  defp update_sc_command(%__MODULE__{} = ugen) do
-    %__MODULE__{osc: osc, lfo: lfo} = ugen
-    ugen |> struct!(sc_command: ugen |> build_sc_command(osc) |> check_lfo(lfo))
-  end
-
-  defp build_sc_command(%__MODULE__{} = ugen, :sin) do
-    %__MODULE__{freq: freq, phase: phase, mul: mul, add: add} = ugen
-    "SinOsc.ar(freq: #{freq}, phase: #{phase}, mul: #{mul}, add: #{add});"
-  end
-
-  defp build_sc_command(%__MODULE__{} = ugen, :saw) do
-    %__MODULE__{freq: freq, mul: mul, add: add} = ugen
-    "Saw.ar(freq: #{freq}, mul: #{mul}, add: #{add});"
-  end
-
-  defp build_sc_command(%__MODULE__{} = ugen, :pulse) do
-    %__MODULE__{freq: freq, width: width, mul: mul, add: add} = ugen
-    "Pulse.ar(freq: #{freq}, width: #{width}, mul: #{mul}, add: #{add});"
-  end
-
-  defp check_lfo(sc_command, lfo) when lfo, do: sc_command |> String.replace("ar(", "kr(")
-  defp check_lfo(sc_command, _lfo), do: sc_command
+  @spec add(struct(), integer() | float() | binary() | struct()) :: struct()
+  def add(ugen, add), do: ugen |> struct!(add: add)
 end

--- a/lib/supex/ugen/pulse.ex
+++ b/lib/supex/ugen/pulse.ex
@@ -13,7 +13,7 @@ defmodule Supex.Ugen.Pulse do
 
   `add` this value will be added to the output.
   """
-  defstruct freq: 440, width: 0, mul: 0.1, add: 0, lfo: false
+  defstruct freq: 440, width: 0.5, mul: 0.2, add: 0, lfo: false
 
   @doc """
   Builds the SuperCollider command from the `%Pulse{}` struct.

--- a/lib/supex/ugen/pulse.ex
+++ b/lib/supex/ugen/pulse.ex
@@ -32,7 +32,7 @@ defmodule Supex.Ugen.Pulse do
     "Pulse.ar(freq: #{freq}, width: #{width}, mul: #{mul}, add: #{add});" |> check_lfo(lfo)
   end
 
-  # `kr` (control rate) instead of `ar`(audio rate) for LFOs
+  # `kr` (control rate) instead of `ar`(audio rate) for LFO usage
   defp check_lfo(sc_command, lfo) when lfo, do: sc_command |> String.replace("ar(", "kr(")
   defp check_lfo(sc_command, _lfo), do: sc_command
 end

--- a/lib/supex/ugen/pulse.ex
+++ b/lib/supex/ugen/pulse.ex
@@ -1,0 +1,38 @@
+defmodule Supex.Ugen.Pulse do
+  @moduledoc """
+  Module for the SuperCollider Pulse wave generator,
+  see https://doc.sccode.org/Classes/Pulse.html
+
+  Defines a `%Pulse{}` struct with
+
+  `freq` frequency in Hertz,
+
+  `width` pulse width ratio from zero to one (0.5 makes a square wave)
+
+  `mul` output will be multiplied by this value,
+
+  `add` this value will be added to the output.
+  """
+  defstruct freq: 440, width: 0, mul: 0.1, add: 0, lfo: false
+
+  @doc """
+  Builds the SuperCollider command from the `%Pulse{}` struct.
+
+  ## example
+
+  iex> %Pulse{freq: 440, width: 0, mul: 0.1, add: 0, lfo: false}
+  "Pulse.ar(freq: 440, width: 0, mul: 0.1, add: 0);"
+
+  iex> %Pulse{freq: 440, width: 0, mul: 0.1, add: 0, lfo: true}
+  "Pulse.kr(freq: 440, width: 0, mul: 0.1, add: 0);"
+  """
+  @spec command(struct()) :: binary()
+  def command(%__MODULE__{} = pulse) do
+    %__MODULE__{freq: freq, width: width, mul: mul, add: add, lfo: lfo} = pulse
+    "Pulse.ar(freq: #{freq}, width: #{width}, mul: #{mul}, add: #{add});" |> check_lfo(lfo)
+  end
+
+  # `kr` (control rate) instead of `ar`(audio rate) for LFOs
+  defp check_lfo(sc_command, lfo) when lfo, do: sc_command |> String.replace("ar(", "kr(")
+  defp check_lfo(sc_command, _lfo), do: sc_command
+end

--- a/lib/supex/ugen/saw.ex
+++ b/lib/supex/ugen/saw.ex
@@ -1,0 +1,37 @@
+defmodule Supex.Ugen.Saw do
+  @moduledoc """
+  Module for the SuperCollider Saw wave generator,
+  see https://doc.sccode.org/Classes/Saw.html
+
+  Defines a `%Saw{}` struct with
+
+  `freq:` frequency in Hertz,
+
+  `mul` output will be multiplied by this value,
+
+  `add` this value will be added to the output.
+
+  """
+  defstruct freq: 440, mul: 0.1, add: 0, lfo: false
+
+  @doc """
+  Builds the SuperCollider command from the `%Saw{}` struct.
+
+  ## example
+
+  iex> %Saw{freq: 440, mul: 0.1, add: 0, lfo: false}
+  "Saw.ar(freq: 440, mul: 0.1, add: 0);"
+
+  iex> %Saw{freq: 440, mul: 0.1, add: 0, lfo: true}
+  "Saw.kr(freq: 440, mul: 0.1, add: 0);"
+  """
+  @spec command(struct()) :: binary()
+  def command(%__MODULE__{} = saw) do
+    %__MODULE__{freq: freq, mul: mul, add: add, lfo: lfo} = saw
+    "Saw.ar(freq: #{freq}, mul: #{mul}, add: #{add});" |> check_lfo(lfo)
+  end
+
+  # `kr` (control rate) instead of `ar`(audio rate) for LFOs
+  defp check_lfo(sc_command, lfo) when lfo, do: sc_command |> String.replace("ar(", "kr(")
+  defp check_lfo(sc_command, _lfo), do: sc_command
+end

--- a/lib/supex/ugen/saw.ex
+++ b/lib/supex/ugen/saw.ex
@@ -31,7 +31,7 @@ defmodule Supex.Ugen.Saw do
     "Saw.ar(freq: #{freq}, mul: #{mul}, add: #{add});" |> check_lfo(lfo)
   end
 
-  # `kr` (control rate) instead of `ar`(audio rate) for LFOs
+  # `kr` (control rate) instead of `ar`(audio rate) for LFO usage
   defp check_lfo(sc_command, lfo) when lfo, do: sc_command |> String.replace("ar(", "kr(")
   defp check_lfo(sc_command, _lfo), do: sc_command
 end

--- a/lib/supex/ugen/sin_osc.ex
+++ b/lib/supex/ugen/sin_osc.ex
@@ -1,0 +1,40 @@
+defmodule Supex.Ugen.SinOsc do
+  @moduledoc """
+  Module for the SuperCollider SinOsc sine wave generator,
+  see https://doc.sccode.org/Classes/SinOsc.html
+
+
+  Defines a `%SinOsc{}` struct with
+
+  `freq:` frequency in Hertz,
+
+  `phase`	phase in radians (should be within the range +-8pi),
+
+  `mul` output will be multiplied by this value,
+
+  `add` this value will be added to the output.
+
+  """
+  defstruct freq: 440, phase: 0, mul: 0.1, add: 0, lfo: false
+
+  @doc """
+  Builds the SuperCollider command from the `%SinOsc{}` struct.
+
+  ## example
+
+  iex> %SinOsc{freq: 440, phase: 0, mul: 0.1, add: 0, lfo: false}
+  "SinOsc.ar(freq: 440, phase: 0, mul: 0.1, add: 0);"
+
+  iex> %SinOsc{freq: 440, phase: 0, mul: 0.1, add: 0, lfo: true}
+  "SinOsc.kr(freq: 440, phase: 0, mul: 0.1, add: 0);"
+  """
+  @spec command(struct()) :: binary()
+  def command(%__MODULE__{} = sin_osc) do
+    %__MODULE__{freq: freq, phase: phase, mul: mul, add: add, lfo: lfo} = sin_osc
+    "SinOsc.ar(freq: #{freq}, phase: #{phase}, mul: #{mul}, add: #{add});" |> check_lfo(lfo)
+  end
+
+  # `kr` (control rate) instead of `ar`(audio rate) for LFOs
+  defp check_lfo(sc_command, lfo) when lfo, do: sc_command |> String.replace("ar(", "kr(")
+  defp check_lfo(sc_command, _lfo), do: sc_command
+end

--- a/lib/supex/ugen/sin_osc.ex
+++ b/lib/supex/ugen/sin_osc.ex
@@ -34,7 +34,7 @@ defmodule Supex.Ugen.SinOsc do
     "SinOsc.ar(freq: #{freq}, phase: #{phase}, mul: #{mul}, add: #{add});" |> check_lfo(lfo)
   end
 
-  # `kr` (control rate) instead of `ar`(audio rate) for LFOs
+  # `kr` (control rate) instead of `ar`(audio rate) for LFO usage
   defp check_lfo(sc_command, lfo) when lfo, do: sc_command |> String.replace("ar(", "kr(")
   defp check_lfo(sc_command, _lfo), do: sc_command
 end

--- a/test/supex/command_test.exs
+++ b/test/supex/command_test.exs
@@ -75,7 +75,9 @@ defmodule Supex.CommandTest do
     test "can handle more than one char for naming (SuperCollider's single global vars and environmental vars)" do
       sc_command = "SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0);"
       result_single = "z = { SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0); }.play"
-      result_more_chars = "~space_sound = { SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0); }.play"
+
+      result_more_chars =
+        "~space_sound = { SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0); }.play"
 
       assert Command.play(sc_command, "z") == result_single
       assert Command.play(sc_command, "space_sound") == result_more_chars

--- a/test/supex/command_test.exs
+++ b/test/supex/command_test.exs
@@ -71,11 +71,24 @@ defmodule Supex.CommandTest do
       result = "y = { SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0); }.play"
       assert Command.play(sc_command, "y") == result
     end
+
+    test "can handle more than one char for naming (SuperCollider's single global vars and environmental vars)" do
+      sc_command = "SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0);"
+      result_single = "z = { SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0); }.play"
+      result_more_chars = "~space_sound = { SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0); }.play"
+
+      assert Command.play(sc_command, "z") == result_single
+      assert Command.play(sc_command, "space_sound") == result_more_chars
+    end
   end
 
   describe "stop/1" do
     test "command for stopping the sound referanced by name" do
       assert Command.stop("y") == "y.free\n"
+    end
+
+    test "can handle more than one char for naming (SuperCollider's single global vars and environmental vars)" do
+      assert Command.stop("space_sound") == "~space_sound.free\n"
     end
   end
 end

--- a/test/supex/command_test.exs
+++ b/test/supex/command_test.exs
@@ -1,0 +1,81 @@
+defmodule Supex.CommandTest do
+  use ExUnit.Case, async: true
+
+  alias Supex.Command
+  alias Supex.Ugen.SinOsc
+
+  describe "build/1" do
+    test "takes a ugen struct like %SinOsc{} and returns a string" do
+      assert Command.build(%SinOsc{}) |> is_binary()
+    end
+
+    test "takes a ugen struct like `%SinOsc{}` and returns the SuperCollider command" do
+      sin_osc = %SinOsc{
+        add: 0.6,
+        phase: 0.9,
+        freq: 269,
+        mul: 0.6
+      }
+
+      sc_command = "SinOsc.ar(freq: 269, phase: 0.9, mul: 0.6, add: 0.6);"
+
+      assert sin_osc |> Command.build() == sc_command
+    end
+
+    test "can be rendered with LFOs inside a Ugen to SuperCollider command" do
+      lfo1 = %SinOsc{
+        add: 0,
+        phase: 0,
+        freq: 12,
+        mul: 0.1,
+        lfo: true
+      }
+
+      lfo2 = %SinOsc{
+        add: 300,
+        phase: 0.3,
+        freq: 0.4,
+        mul: 269,
+        lfo: true
+      }
+
+      main_osc = %SinOsc{
+        add: 0,
+        phase: 0,
+        freq: lfo2,
+        mul: lfo1,
+        lfo: false
+      }
+
+      lfo1_command = "SinOsc.kr(freq: 12, phase: 0, mul: 0.1, add: 0);"
+      lfo2_command = "SinOsc.kr(freq: 0.4, phase: 0.3, mul: 269, add: 300);"
+
+      main_osc_command =
+        "SinOsc.ar(freq: #{lfo2_command}, phase: 0, mul: #{lfo1_command}, add: 0);"
+
+      assert main_osc |> Command.build() == main_osc_command
+    end
+  end
+
+  describe "play/1" do
+    test "wrappes a SuperCollider command in play brackets assign default name 'x'" do
+      sc_command = "SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0);"
+      result = "x = { SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0); }.play"
+      assert Command.play(sc_command) == result
+    end
+  end
+
+  describe "play/2" do
+    test "wrappes a SuperCollider command in play brackets assigns given name" do
+      sc_command = "SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0);"
+      result = "y = { SinOsc.ar(freq: 12, phase: 0, mul: 0.1, add: 0); }.play"
+      assert Command.play(sc_command, "y") == result
+    end
+  end
+
+  describe "stop/1" do
+    test "command for stopping the sound referanced by name" do
+      assert Command.stop("y") == "y.free\n"
+    end
+  end
+end

--- a/test/supex/example_test.exs
+++ b/test/supex/example_test.exs
@@ -1,24 +1,27 @@
 defmodule Supex.ExampleTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
+  alias Supex.Command
   alias Supex.Example
 
   describe "pulse_wave_modulation_with_lfo/0" do
-    test "returns example synthesizer SC command" do
-      pulse_wave_example_ugen = %Supex.Ugen{
+    test "returns example SC command" do
+      pulse_wave_example_ugen = %Supex.Ugen.Pulse{
         add: 0,
-        width: "SinOsc.kr(freq: 6, phase: 0, mul: 0.5, add: 0.5);",
-        phase: 0,
-        osc: :pulse,
-        mul: "SinOsc.kr(freq: 2, phase: 0, mul: 0.4, add: 0.5);",
-        freq: "Saw.kr(freq: 0.1, mul: 100, add: 100);",
+        freq: %Supex.Ugen.Saw{add: 100, mul: 100, freq: 0.1, lfo: true},
         lfo: false,
-        sc_command:
-          "Pulse.ar(freq: Saw.kr(freq: 0.1, mul: 100, add: 100);, width: SinOsc.kr(freq: 6, phase: 0, mul: 0.5, add: 0.5);, mul: SinOsc.kr(freq: 2, phase: 0, mul: 0.4, add: 0.5);, add: 0);",
-        sc_name: "x"
+        mul: %Supex.Ugen.SinOsc{add: 0.5, phase: 0, mul: 0.4, freq: 2, lfo: true},
+        width: %Supex.Ugen.SinOsc{add: 0.5, phase: 0, mul: 0.5, freq: 6, lfo: true}
       }
 
       assert Example.pulse_wave_modulation_with_lfo() == pulse_wave_example_ugen
+    end
+
+    test "can be build to SC command" do
+      sc_command_result =
+        "Pulse.ar(freq: Saw.kr(freq: 0.1, mul: 100, add: 100);, width: SinOsc.kr(freq: 6, phase: 0, mul: 0.5, add: 0.5);, mul: SinOsc.kr(freq: 2, phase: 0, mul: 0.4, add: 0.5);, add: 0);"
+
+      assert Example.pulse_wave_modulation_with_lfo() |> Command.build() == sc_command_result
     end
   end
 end

--- a/test/supex/pan_test.exs
+++ b/test/supex/pan_test.exs
@@ -1,5 +1,5 @@
 defmodule Supex.Sclang.PanTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Supex.Pan
   alias Supex.Ugen

--- a/test/supex/sclang_test.exs
+++ b/test/supex/sclang_test.exs
@@ -52,7 +52,7 @@ defmodule Supex.SclangTest do
       sc_command = "{ SinOsc.ar(freq: 369, phase: 0, mul: 0.1, add: 0); }.play"
       result = Sclang.execute(sc_command)
 
-      assert %Supex.Sclang{port: _, sc_server_booted: true} = result
+      assert %Sclang{port: _, sc_server_booted: true} = result
     end
   end
 
@@ -73,7 +73,12 @@ defmodule Supex.SclangTest do
       {:ok, _pid} = start_supervised(Sclang)
       # wait for sc server to boot
       Process.sleep(4000)
-      assert Sclang.stop_playing() == :ok
+
+      assert %Sclang{
+               port: _port,
+               sc_server_booted: true,
+               last_command_executed: "s.freeAll\n"
+             } = Sclang.stop_playing()
     end
   end
 

--- a/test/supex/ugen/pulse_test.exs
+++ b/test/supex/ugen/pulse_test.exs
@@ -4,8 +4,8 @@ defmodule Supex.Ugen.PulseTest do
   alias Supex.Ugen.Pulse
 
   describe "%Pulse{} struct" do
-    test "returns default %SinOsc{} struct" do
-      assert %Pulse{freq: 440, width: 0, mul: 0.1, add: 0} = %Pulse{}
+    test "returns default %Pulse{} struct" do
+      assert %Pulse{freq: 440, width: 0.5, mul: 0.2, add: 0} = %Pulse{}
     end
   end
 

--- a/test/supex/ugen/pulse_test.exs
+++ b/test/supex/ugen/pulse_test.exs
@@ -1,0 +1,23 @@
+defmodule Supex.Ugen.PulseTest do
+  use ExUnit.Case, async: true
+
+  alias Supex.Ugen.Pulse
+
+  describe "%Pulse{} struct" do
+    test "returns default %SinOsc{} struct" do
+      assert %Pulse{freq: 440, width: 0, mul: 0.1, add: 0} = %Pulse{}
+    end
+  end
+
+  describe "command/1" do
+    test "returns Pulse command" do
+      pulse = %Pulse{freq: 69, width: 0.2, mul: 0.6, add: 0.9}
+      assert Pulse.command(pulse) == "Pulse.ar(freq: 69, width: 0.2, mul: 0.6, add: 0.9);"
+    end
+
+    test "for LFO true returns Pulse command with kr" do
+      pulse = %Pulse{freq: 69, width: 0.2, mul: 0.6, add: 0.9, lfo: true}
+      assert Pulse.command(pulse) == "Pulse.kr(freq: 69, width: 0.2, mul: 0.6, add: 0.9);"
+    end
+  end
+end

--- a/test/supex/ugen/saw_test.exs
+++ b/test/supex/ugen/saw_test.exs
@@ -1,0 +1,18 @@
+defmodule Supex.Ugen.SawTest do
+  use ExUnit.Case, async: true
+
+  alias Supex.Ugen.Saw
+
+  describe "%Saw{} struct" do
+    test "returns default %SinOsc{} struct" do
+      assert %Saw{freq: 440, mul: 0.1, add: 0} = %Saw{}
+    end
+  end
+
+  describe "command/1" do
+    test "returns Saw command" do
+      saw = %Saw{freq: 69, mul: 0.6, add: 0.9}
+      assert Saw.command(saw) == "Saw.ar(freq: 69, mul: 0.6, add: 0.9);"
+    end
+  end
+end

--- a/test/supex/ugen/sin_osc_test.exs
+++ b/test/supex/ugen/sin_osc_test.exs
@@ -1,0 +1,18 @@
+defmodule Supex.Ugen.SinOscTest do
+  use ExUnit.Case, async: true
+
+  alias Supex.Ugen.SinOsc
+
+  describe "%SinOsc{} struct" do
+    test "returns default %SinOsc{} struct" do
+      assert %SinOsc{freq: 440, phase: 0, mul: 0.1, add: 0} = %SinOsc{}
+    end
+  end
+
+  describe "command/1" do
+    test "returns SinOsc command" do
+      sin_osc = %SinOsc{freq: 69, phase: 0.9, mul: 0.6, add: 0.9}
+      assert SinOsc.command(sin_osc) == "SinOsc.ar(freq: 69, phase: 0.9, mul: 0.6, add: 0.9);"
+    end
+  end
+end

--- a/test/supex/ugen_test.exs
+++ b/test/supex/ugen_test.exs
@@ -4,118 +4,75 @@ defmodule Supex.UgenTest do
   doctest Supex.Ugen
 
   alias Supex.Ugen
+  alias Supex.Ugen.Pulse
+  alias Supex.Ugen.Saw
+  alias Supex.Ugen.SinOsc
 
   describe "osc/1" do
     test "generic oscillator composing a SINUS wave oscillator" do
-      %Ugen{sc_command: sc_command} = Ugen.osc(:sin)
-      assert sc_command == "SinOsc.ar(freq: 440, phase: 0, mul: 0.1, add: 0);"
+      ugen = %SinOsc{freq: 440, phase: 0, mul: 0.1, add: 0}
+      assert ugen == Ugen.sin()
     end
 
     test "generic oscillator composing a SAW wave oscillator" do
-      %Ugen{sc_command: sc_command} = Ugen.osc(:saw)
-      assert sc_command == "Saw.ar(freq: 440, mul: 0.1, add: 0);"
+      ugen = %Saw{freq: 440, mul: 0.1, add: 0}
+      assert ugen == Ugen.saw()
     end
 
     test "generic oscillator composing a PULSE (Square) wave oscillator" do
-      %Ugen{sc_command: sc_command} = Ugen.osc(:pulse)
-      assert sc_command == "Pulse.ar(freq: 440, width: 0.5, mul: 0.1, add: 0);"
+      ugen = %Pulse{freq: 440, width: 0, mul: 0.1, add: 0}
+      assert ugen == Ugen.pulse()
     end
   end
 
   describe "oscillator composing" do
     test "osc/1" do
-      ugen = %Ugen{freq: 550, phase: 4, mul: 0.2, add: 0.3}
-      %Ugen{sc_command: sc_command} = Ugen.osc(ugen)
-      assert sc_command == "SinOsc.ar(freq: 550, phase: 4, mul: 0.2, add: 0.3);"
+      ugen = %SinOsc{freq: 440, phase: 0, mul: 0.1, add: 0}
+      assert ugen == Ugen.sin()
     end
 
     test "freq/1" do
-      ugen = %Ugen{freq: 550, phase: 4, mul: 0.2, add: 0.3}
-      %Ugen{sc_command: sc_command} = Ugen.osc(ugen) |> Ugen.freq(690)
-      assert sc_command == "SinOsc.ar(freq: 690, phase: 4, mul: 0.2, add: 0.3);"
+      ugen = %SinOsc{freq: 550, phase: 4, mul: 0.2, add: 0.3}
+      result = %SinOsc{freq: 690, phase: 4, mul: 0.2, add: 0.3}
+      assert ugen |> Ugen.freq(690) == result
     end
 
     test "phase/1" do
-      ugen = %Ugen{freq: 550, phase: 4, mul: 0.2, add: 0.3}
-      %Ugen{sc_command: sc_command} = Ugen.osc(ugen) |> Ugen.phase(2)
-      assert sc_command == "SinOsc.ar(freq: 550, phase: 2, mul: 0.2, add: 0.3);"
+      ugen = %SinOsc{freq: 550, phase: 4, mul: 0.2, add: 0.3}
+      result = %SinOsc{freq: 550, phase: 2, mul: 0.2, add: 0.3}
+      assert ugen |> Ugen.phase(2) == result
     end
 
     test "mul/1" do
-      ugen = %Ugen{freq: 550, phase: 4, mul: 0.2, add: 0.3}
-      %Ugen{sc_command: sc_command} = Ugen.osc(ugen) |> Ugen.mul(0.4)
-      assert sc_command == "SinOsc.ar(freq: 550, phase: 4, mul: 0.4, add: 0.3);"
+      ugen = %SinOsc{freq: 550, phase: 4, mul: 0.2, add: 0.3}
+      result = %SinOsc{freq: 550, phase: 4, mul: 2, add: 0.3}
+      assert ugen |> Ugen.mul(2) == result
     end
 
     test "add/1" do
-      ugen = %Ugen{freq: 550, phase: 4, mul: 0.2, add: 0.6}
-      %Ugen{sc_command: sc_command} = Ugen.osc(ugen) |> Ugen.add(0.6)
-      assert sc_command == "SinOsc.ar(freq: 550, phase: 4, mul: 0.2, add: 0.6);"
-    end
-
-    test "name/1" do
-      ugen = %Ugen{freq: 550, phase: 4, mul: 0.2, add: 0.6}
-      %Ugen{sc_name: sc_name} = Ugen.osc(ugen) |> Ugen.name("x")
-      assert sc_name == "x"
+      ugen = %SinOsc{freq: 550, phase: 4, mul: 0.2, add: 0.3}
+      result = %SinOsc{freq: 550, phase: 4, mul: 0.2, add: 0.6}
+      assert ugen |> Ugen.add(0.6) == result
     end
 
     test "all composing" do
-      %Ugen{sc_command: sc_command} =
-        Ugen.osc() |> Ugen.freq(690) |> Ugen.phase(6) |> Ugen.mul(0.9) |> Ugen.add(0.69)
-
-      assert sc_command == "SinOsc.ar(freq: 690, phase: 6, mul: 0.9, add: 0.69);"
+      ugen = Ugen.sin() |> Ugen.freq(690) |> Ugen.phase(6) |> Ugen.mul(0.9) |> Ugen.add(0.69)
+      result = %SinOsc{freq: 690, phase: 6, mul: 0.9, add: 0.69}
+      assert ugen == result
     end
   end
 
   describe "lfo/1" do
-    test "transform a oscillator to a LFO sc_command" do
-      ugen = %Ugen{
-        osc: :sin,
-        freq: 4,
-        phase: 0,
-        mul: 0.2,
-        add: 0.4,
-        lfo: false
-      }
-
-      sc_command = ugen |> Ugen.lfo()
-      assert sc_command == "SinOsc.kr(freq: 4, phase: 0, mul: 0.2, add: 0.4);"
+    test "set LFO true for a sine oscillator" do
+      ugen = %SinOsc{freq: 4, phase: 0, mul: 0.2, add: 0.4, lfo: false}
+      result = %SinOsc{freq: 4, phase: 0, mul: 0.2, add: 0.4, lfo: true}
+      assert ugen |> Ugen.lfo() == result
     end
 
-    test "transform a SAW oscillator to a LFO sc_command" do
-      ugen = %Ugen{
-        osc: :saw,
-        freq: 5,
-        mul: 0.1,
-        add: 0,
-        lfo: false
-      }
-
-      sc_command = ugen |> Ugen.lfo()
-      assert sc_command == "Saw.kr(freq: 5, mul: 0.1, add: 0);"
+    test "set LFO true for a Saw oscillator" do
+      ugen = %Saw{freq: 5, mul: 0.1, add: 0, lfo: false}
+      result = %Saw{freq: 5, mul: 0.1, add: 0, lfo: true}
+      assert ugen |> Ugen.lfo() == result
     end
-  end
-
-  describe "play/1" do
-    test "add play and name to oscillator command from %Ugen{}" do
-      ugen = %Ugen{freq: 550, phase: 4, mul: 0.2, add: 0.3, sc_name: "y"}
-      sc_command = ugen |> Ugen.osc() |> Ugen.play()
-      assert sc_command == "y = { SinOsc.ar(freq: 550, phase: 4, mul: 0.2, add: 0.3); }.play"
-    end
-
-    test "add play and name to raw command string" do
-      cmd_without = "RLPF.ar(Pulse.ar([100, 250], 0.5, 0.1), XLine.kr(8000, 400, 5), 0.05)"
-
-      cmd_name_play =
-        "x = { RLPF.ar(Pulse.ar([100, 250], 0.5, 0.1), XLine.kr(8000, 400, 5), 0.05) }.play"
-
-      assert cmd_without |> Ugen.play() == cmd_name_play
-    end
-  end
-
-  test "stop sine oscillator command" do
-    ugen = %Ugen{freq: 550, phase: 4, mul: 0.2, add: 0.3, sc_name: "y"}
-    sc_command = ugen |> Ugen.osc() |> Ugen.stop()
-    assert sc_command == "y.free\n"
   end
 end

--- a/test/supex/ugen_test.exs
+++ b/test/supex/ugen_test.exs
@@ -20,7 +20,7 @@ defmodule Supex.UgenTest do
     end
 
     test "generic oscillator composing a PULSE (Square) wave oscillator" do
-      ugen = %Pulse{freq: 440, width: 0, mul: 0.1, add: 0}
+      ugen = %Pulse{freq: 440, width: 0.5, mul: 0.2, add: 0}
       assert ugen == Ugen.pulse()
     end
   end

--- a/test/supex_test.exs
+++ b/test/supex_test.exs
@@ -1,6 +1,7 @@
 defmodule SupexTest do
   use ExUnit.Case, async: true
 
+  alias Supex.Sclang
   alias Supex.Ugen.SinOsc
 
   describe "osc/0" do
@@ -32,9 +33,36 @@ defmodule SupexTest do
     end
   end
 
+  describe "play/1" do
+    test "returns a %Sclang{} struct" do
+      {:ok, _pid} = start_supervised(Sclang)
+      # wait for sc server to boot
+      Process.sleep(4000)
+
+      ugen = %SinOsc{freq: 4, phase: 0, mul: 0.2, add: 0.4, lfo: false}
+      assert %Sclang{} = Supex.play(ugen)
+    end
+  end
+
+  describe "play/2" do
+    test "returns a %Sclang{} struct with name in the executed command" do
+      {:ok, _pid} = start_supervised(Sclang)
+      # wait for sc server to boot
+      Process.sleep(4000)
+
+      ugen = %SinOsc{freq: 4, phase: 0, mul: 0.2, add: 0.4, lfo: false}
+      assert %Sclang{last_command_executed: command} = Supex.play(ugen, "z")
+      assert command =~ "z = "
+    end
+  end
+
   describe "stop/0" do
     test "stops all playing sounds" do
-      assert Supex.stop() == :ok
+      {:ok, _pid} = start_supervised(Sclang)
+      # wait for sc server to boot
+      Process.sleep(4000)
+
+      assert %Sclang{} = Supex.stop()
     end
   end
 end

--- a/test/supex_test.exs
+++ b/test/supex_test.exs
@@ -1,28 +1,17 @@
 defmodule SupexTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
-  alias Supex.Ugen
+  alias Supex.Ugen.SinOsc
 
   describe "osc/0" do
-    test "returns a %Ugen sin oscillator" do
-      assert %Supex.Ugen{
-               add: 0,
-               width: 0.5,
-               phase: 0,
-               sc_command: "SinOsc.ar(freq: 440, phase: 0, mul: 0.1, add: 0);",
-               osc: :sin,
-               freq: 440,
-               mul: 0.1,
-               sc_name: "x",
-               lfo: false
-             } = Supex.osc()
+    test "returns a %SinOsc sin oscillator" do
+      assert %SinOsc{add: 0, phase: 0, freq: 440, mul: 0.1, lfo: false} = Supex.sin()
     end
   end
 
   describe "lfo/1" do
-    test "transforms the oscillator to an LFO SuperCollider's command" do
-      ugen = %Ugen{
-        osc: :sin,
+    test "sets the LFO to true" do
+      ugen = %SinOsc{
         freq: 4,
         phase: 0,
         mul: 0.2,
@@ -30,41 +19,22 @@ defmodule SupexTest do
         lfo: false
       }
 
-      assert ugen |> Supex.lfo() == "SinOsc.kr(freq: 4, phase: 0, mul: 0.2, add: 0.4);"
+      assert %SinOsc{lfo: true} = ugen |> Supex.lfo()
     end
   end
 
   describe "phase/2" do
     test "gets the oscillator as an LFO SuperCollider's command" do
-      ugen = %Ugen{
-        osc: :sin,
-        freq: 4,
-        phase: 0,
-        mul: 0.2,
-        add: 0.4,
-        lfo: false
-      }
+      ugen = %SinOsc{freq: 4, phase: 0, mul: 0.2, add: 0.4, lfo: false}
+      result = %SinOsc{freq: 4, phase: 0.6, mul: 0.2, add: 0.4, lfo: false}
 
-      ugen_with_phase = ugen |> Supex.phase(0.6)
-
-      assert ugen_with_phase.sc_command == "SinOsc.ar(freq: 4, phase: 0.6, mul: 0.2, add: 0.4);"
+      assert ugen |> Supex.phase(0.6) == result
     end
   end
 
-  describe "name/2" do
-    test "gets the oscillator as an LFO SuperCollider's command" do
-      ugen = %Ugen{
-        osc: :sin,
-        freq: 4,
-        phase: 0,
-        mul: 0.2,
-        add: 0.4,
-        lfo: false
-      }
-
-      ugen_with_name = ugen |> Supex.name("z")
-
-      assert ugen_with_name.sc_name == "z"
+  describe "stop/0" do
+    test "stops all playing sounds" do
+      assert Supex.stop() == :ok
     end
   end
 end


### PR DESCRIPTION
This PR restructures the core of Supex to improve flexibility, clarity, and maintainability.

### Changes

- Fixed inconsistent naming behavior (supports multi-character names)
- Allowed all parameters (`freq`, `width`, etc.) to accept LFOs
- Modularized internal structure for better extensibility
- Updated tests and adjusted documentation accordingly

### Notes

These changes are **breaking** and affect how parameter composition works internally.
